### PR TITLE
Adjust 'move to next page' to avoid infinite render errors

### DIFF
--- a/addon/services/document-data.js
+++ b/addon/services/document-data.js
@@ -3,7 +3,7 @@ import EmberObject, { computed } from "@ember/object";
 import { A } from "@ember/array";
 import { array, equal, difference } from "ember-awesome-macros";
 import { alias } from "@ember/object/computed";
-import { run } from "@ember/runloop";
+import { next } from "@ember/runloop";
 
 /*
  * Report
@@ -91,7 +91,7 @@ const Chapter = EmberObject.extend({
   },
 
   moveLastItemToNextPage(pageIndex) {
-    run(() => {
+    next(() => {
       // Find sections with data in page at pageIndex
       let sectionsInPage = this.sections.filter(
         section => !!section.pages[pageIndex]

--- a/tests/dummy/app/controllers/demos/default.js
+++ b/tests/dummy/app/controllers/demos/default.js
@@ -2,10 +2,15 @@ import Controller from "@ember/controller";
 import { computed } from "@ember/object";
 
 export default Controller.extend({
+  queryParams: ["dataLength", "columnCount", "chapterCount"],
   dataLength: 1000,
   columnCount: 2,
+  chapterCount: 1,
   sectionData: computed("dataLength", function() {
     return [...Array(Number(this.dataLength))].map((_, i) => i);
+  }),
+  chapters: computed("chapterCount", function() {
+    return [...Array(Number(this.chapterCount))].map((_, i) => i);
   }),
 
   actions: {

--- a/tests/dummy/app/templates/demos/default.hbs
+++ b/tests/dummy/app/templates/demos/default.hbs
@@ -8,7 +8,11 @@
     renderTime=this.renderTime
   }}
 
+  <label>Chapter Count</label>
+  {{input type="number" value=this.chapterCount min=1}}
+  <label>Section Count</label>
   {{input type="number" value=this.dataLength min=1 max=10000}}
+  <label>Column Count</label>
   {{input type="number" value=this.columnCount min=1 max=3}}
 </div>
 
@@ -16,42 +20,45 @@
   onRenderStart=(action "start")
   onRenderProgress=(action "updateProgress")
   onRenderComplete=(action "complete")
+  rerender=this.chapterCount
   as |document|
 }}
-  {{#document.chapter as |chapter|}}
-    {{#chapter.page-header as |header|}}
-      <div>
-        <div>Chapter {{header.pageMeta.chapterNumber}}</div>
-        <div>page {{header.pageMeta.current}} of {{header.pageMeta.total}}</div>
-      </div>
-    {{/chapter.page-header}}
+  {{#each chapters}}
+    {{#document.chapter as |chapter|}}
+      {{#chapter.page-header as |header|}}
+        <div>
+          <div>Chapter {{header.pageMeta.chapterNumber}}</div>
+          <div>page {{header.pageMeta.current}} of {{header.pageMeta.total}}</div>
+        </div>
+      {{/chapter.page-header}}
 
-    {{#chapter.section}}
-      <h3>Section 1</h3>
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sapien ligula,
-        scelerisque et imperdiet sit amet, imperdiet sit amet nisi. Nulla sit amet neque
-        ullamcorper lorem tincidunt facilisis. Morbi ante risus, consectetur id feugiat
-        nec, interdum ac enim. Phasellus molestie placerat lorem et pharetra. Aenean congue
-        tempor viverra. Nulla volutpat, est ut sagittis posuere, nisl metus luctus eros,
-        id feugiat erat tortor et felis. Pellentesque id nisl non justo viverra lacinia
-        id sit amet arcu. Mauris non euismod ipsum. Fusce lacinia felis nec euismod vulputate.
-      </p>
-    {{/chapter.section}}
+      {{#chapter.section}}
+        <h3>Section 1</h3>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sapien ligula,
+          scelerisque et imperdiet sit amet, imperdiet sit amet nisi. Nulla sit amet neque
+          ullamcorper lorem tincidunt facilisis. Morbi ante risus, consectetur id feugiat
+          nec, interdum ac enim. Phasellus molestie placerat lorem et pharetra. Aenean congue
+          tempor viverra. Nulla volutpat, est ut sagittis posuere, nisl metus luctus eros,
+          id feugiat erat tortor et felis. Pellentesque id nisl non justo viverra lacinia
+          id sit amet arcu. Mauris non euismod ipsum. Fusce lacinia felis nec euismod vulputate.
+        </p>
+      {{/chapter.section}}
 
-    {{#chapter.section columnCount=this.columnCount data=this.sectionData as |section|}}
-      {{#if (eq section.index 0)}}
-        <h3>Section 2</h3>
-      {{/if}}
+      {{#chapter.section columnCount=this.columnCount data=this.sectionData as |section|}}
+        {{#if (eq section.index 0)}}
+          <h3>Section 2</h3>
+        {{/if}}
 
-      <h4>Section 2 {{section.data}}</h4>
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-      </p>
-    {{/chapter.section}}
+        <h4>Section 2 {{section.data}}</h4>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        </p>
+      {{/chapter.section}}
 
-    {{#chapter.page-footer as |footer|}}
-      <div>Footer page {{footer.pageMeta.current}} of {{footer.pageMeta.total}}</div>
-    {{/chapter.page-footer}}
-  {{/document.chapter}}
+      {{#chapter.page-footer as |footer|}}
+        <div>Footer page {{footer.pageMeta.current}} of {{footer.pageMeta.total}}</div>
+      {{/chapter.page-footer}}
+    {{/document.chapter}}
+  {{/each}}
 {{/printable-pages}}


### PR DESCRIPTION
- Adjust the move to next page logic so that it avoids infinite render
error
- Add new customization input in the deafult demo to facilitate testing
documents with variable number of chapters

Fixes #15