### PR TITLE
Guard RenderNextPage

### DIFF
--- a/addon/services/document-data.js
+++ b/addon/services/document-data.js
@@ -55,6 +55,7 @@ export default Service.extend({
   },
 
   addPage(reportId, chapterId) {
+    // console.log(`<service:document-data> addPage(${reportId}, ${chapterId})`);
     let report = this.reports[reportId];
     let chapter = report.chapterMap[chapterId];
     let chapterIndex = report.chapters.indexOf(chapter);

--- a/addon/util-models/chapter.js
+++ b/addon/util-models/chapter.js
@@ -123,8 +123,11 @@ export default EmberObject.extend({
       } else if (!lastSectionInPage.isFullyRendered) {
         lastSectionInPage.reconcilePageStartIndex(pageIndex + 1);
       } else {
+        //Ensure there are any other sections left.
         let nextSection = this.sections[lastSectionInPage.index + 1];
-        nextSection.addItemToPage(pageIndex + 1);
+        if(nextSection) {
+          nextSection.addItemToPage(pageIndex + 1);
+        }
       }
     });
   }

--- a/addon/util-models/chapter.js
+++ b/addon/util-models/chapter.js
@@ -26,7 +26,15 @@ export default EmberObject.extend({
     return this.sections.isEvery("isFullyRendered");
   }),
 
+  instrument() {
+    // eslint-disable-next-line no-console
+    this.sections.map(s => console.log(s.toString(), s.pages.toArray()));
+  },
+
   renderNextItem(pageIndex, remainingHeight) {
+    // console.log(`Chapter#renderNextItem(${pageIndex}, ${remainingHeight})`);
+    // this.instrument();
+
     let section = this.sections.findBy("isFullyRendered", false);
 
     // If no section, then this chapter is done!
@@ -57,6 +65,9 @@ export default EmberObject.extend({
     }
 
     section.updateIsFullyRendered();
+    // console.log(`-------`);
+    // this.instrument();
+    // console.log(`</> Chapter#renderNextItem(${pageIndex}, ${remainingHeight})`);
   },
 
   lastSectionInPage(pageIndex) {
@@ -72,22 +83,33 @@ export default EmberObject.extend({
   },
 
   removeItemFromPage(pageIndex) {
+    // console.log(`Chapter#removeItemFromPage(${pageIndex})`);
+    // this.instrument();
+
     let section = this.lastSectionInPage(pageIndex);
     let pageInSection = section.pages.objectAt(pageIndex);
 
     // Take an item away from the current page
     if (pageInSection.endIndex === 0) {
       section.pages.removeAt(pageIndex);
+      section.pages.insertAt(pageIndex, null);
     } else {
       pageInSection.decrementProperty("endIndex");
     }
     section.decrementProperty("nextItemIndex");
     section.set("isFullyRendered", false);
+
+    // console.log("------");
+    // this.instrument();
+    // console.log(`</> Chapter#removeItemFromPage(${pageIndex})`);
   },
 
   // Rename to 'removeLastItem'
   moveLastItemToNextPage(pageIndex, addPage) {
     next(() => {
+      // console.log(`Chapter#moveLastItemToNextPage(${pageIndex}, fn)`);
+      // this.instrument();
+
       let itemCountForPage = this.itemCountForPage(pageIndex);
 
       // If there is only one item on the page, don't remove it
@@ -112,6 +134,8 @@ export default EmberObject.extend({
 
   renderNextPage(pageIndex, addPage) {
     next(() => {
+      // console.log(`Chapter#renderNextPage(${pageIndex}, fn)`);
+      // this.instrument();
       let chapterPage = this.pages.objectAt(pageIndex + 1);
       if (!chapterPage) addPage(this.id);
 
@@ -125,10 +149,15 @@ export default EmberObject.extend({
       } else {
         //Ensure there are any other sections left.
         let nextSection = this.sections[lastSectionInPage.index + 1];
-        if(nextSection) {
+        if (nextSection) {
           nextSection.addItemToPage(pageIndex + 1);
+          nextSection.updateIsFullyRendered();
         }
       }
+
+      // console.log("----");
+      // this.instrument();
+      // console.log(`</> Chapter#renderNextPage(${pageIndex}, fn)`);
     });
   }
 });

--- a/addon/util-models/section.js
+++ b/addon/util-models/section.js
@@ -18,6 +18,13 @@ export default EmberObject.extend({
   itemHeightDiff: computed("maxItemHeight", "minItemHeight", function() {
     return this.maxItemHeight - this.minItemHeight;
   }),
+
+  toString() {
+    return `<section:${this.id}> ${this.data.length} items, nextItemIndex ${
+      this.nextItemIndex
+    }, isFullyRendered ${this.isFullyRendered}`;
+  },
+
   itemCountForPage(pageIndex) {
     let page = this.pages.objectAt(pageIndex);
     if (!page) return 0;
@@ -52,6 +59,7 @@ export default EmberObject.extend({
     } else {
       this.pages.pushObject(page);
     }
+    // this.updateIsFullyRendered();
   },
 
   addItemToPage(pageIndex) {
@@ -61,6 +69,7 @@ export default EmberObject.extend({
     } else {
       page.incrementProperty("endIndex");
       this.incrementProperty("nextItemIndex");
+      // this.updateIsFullyRendered();
     }
   }
 });

--- a/tests/integration/components/printable-pages-test.js
+++ b/tests/integration/components/printable-pages-test.js
@@ -720,4 +720,230 @@ module("Integration | Component | printable-pages", function(hooks) {
         .exists({ count: 9 });
     });
   });
+
+  module("page sized section items (not using the iterator)", function() {
+    let renderTemplate = function(context) {
+      context.set("sectionCount", context.sectionCount);
+
+      return render(hbs`
+        {{#printable-pages as |document|}}
+          {{#document.chapter as |chapter|}}
+            {{! template-lint-disable no-inline-styles}}
+            {{#chapter.page-header as |header|}}
+              <div style="height: 50px; margin-bottom: 5px; background-color: rgba(0,0,0,0.08);">
+              </div>
+            {{/chapter.page-header}}
+
+            {{#chapter.section}}
+              <div style="height: 750px; background-color: rgba(0,0,0,0.12);">item 1</div>
+            {{/chapter.section}}
+
+            {{#if (gt this.sectionCount 1)}}
+              {{#chapter.section}}
+                <div style="height: 750px; background-color: rgba(0,0,0,0.12);">item 2</div>
+              {{/chapter.section}}
+            {{/if}}
+
+            {{#if (gt this.sectionCount 2)}}
+              {{#chapter.section}}
+                <div style="height: 750px; background-color: rgba(0,0,0,0.12);">item 3</div>
+              {{/chapter.section}}
+            {{/if}}
+
+            {{#if (gt this.sectionCount 3)}}
+              {{#chapter.section}}
+                <div style="height: 750px; background-color: rgba(0,0,0,0.12);">item 4</div>
+              {{/chapter.section}}
+            {{/if}}
+
+            {{#if (gt this.sectionCount 4)}}
+              {{#chapter.section}}
+                <div style="height: 750px; background-color: rgba(0,0,0,0.12);">item 5</div>
+              {{/chapter.section}}
+            {{/if}}
+
+            {{#chapter.page-footer as |footer|}}
+              <div style="height: 50px; background-color: rgba(0,0,0,0.08);">
+              </div>
+            {{/chapter.page-footer}}
+            {{! template-lint-enable no-inline-styles}}
+          {{/document.chapter}}
+        {{/printable-pages}}
+      `);
+    };
+
+    test("1 item", async function(assert) {
+      this.set("sectionCount", 1);
+
+      await renderTemplate(this);
+
+      assert.dom("[data-test-page]").exists({ count: 1 });
+      assert
+        .dom("[data-test-page='1'] [data-test-section]")
+        .exists({ count: this.sectionCount });
+      assert.dom("[data-test-page='1'] [data-test-page-header]").exists();
+      assert.dom("[data-test-page='1'] [data-test-page-footer]").exists();
+    });
+
+    test("2 items", async function(assert) {
+      this.set("sectionCount", 2);
+
+      await renderTemplate(this);
+
+      assert.dom("[data-test-page]").exists({ count: 2 });
+      assert
+        .dom("[data-test-page='1'] [data-test-section]")
+        .exists({ count: 1 });
+      assert.dom("[data-test-page='1'] [data-test-page-header]").exists();
+      assert.dom("[data-test-page='1'] [data-test-page-footer]").exists();
+
+      assert
+        .dom("[data-test-page='2'] [data-test-section]")
+        .exists({ count: 1 });
+      assert.dom("[data-test-page='2'] [data-test-page-header]").exists();
+      assert.dom("[data-test-page='2'] [data-test-page-footer]").exists();
+    });
+
+    test("3 items", async function(assert) {
+      this.set("sectionCount", 3);
+
+      await renderTemplate(this);
+
+      assert.dom("[data-test-page]").exists({ count: 3 });
+      assert
+        .dom("[data-test-page='1'] [data-test-section]")
+        .exists({ count: 1 });
+      assert.dom("[data-test-page='1'] [data-test-page-header]").exists();
+      assert.dom("[data-test-page='1'] [data-test-page-footer]").exists();
+
+      assert
+        .dom("[data-test-page='2'] [data-test-section]")
+        .exists({ count: 1 });
+      assert.dom("[data-test-page='2'] [data-test-page-header]").exists();
+      assert.dom("[data-test-page='2'] [data-test-page-footer]").exists();
+
+      assert
+        .dom("[data-test-page='3'] [data-test-section]")
+        .exists({ count: 1 });
+      assert.dom("[data-test-page='3'] [data-test-page-header]").exists();
+      assert.dom("[data-test-page='3'] [data-test-page-footer]").exists();
+    });
+
+    test("5 items", async function(assert) {
+      this.set("sectionCount", 5);
+
+      await renderTemplate(this);
+
+      assert.dom("[data-test-page]").exists({ count: 5 });
+      [...Array(Number(this.sectionCount))]
+        .map((_, i) => i + 1)
+        .forEach(i =>
+          assert
+            .dom(`[data-test-page='${i}'] [data-test-section]`)
+            .exists({ count: 1 })
+        );
+    });
+  });
+
+  module("page sized section items (using the iterator)", function() {
+    let renderTemplate = function(context) {
+      context.set(
+        "sectionData",
+        [...Array(Number(context.sectionCount))].map((_, i) => i)
+      );
+      return render(hbs`
+        {{#printable-pages as |document|}}
+          {{#document.chapter as |chapter|}}
+            {{! template-lint-disable no-inline-styles}}
+            {{#chapter.page-header as |header|}}
+              <div style="height: 50px; margin-bottom: 5px; background-color: rgba(0,0,0,0.08);">
+              </div>
+            {{/chapter.page-header}}
+
+            {{#chapter.section data=this.sectionData as |section|}}
+              <div style="height: 750px; background-color: rgba(0,0,0,0.12);">item {{section}}</div>
+            {{/chapter.section}}
+
+            {{#chapter.page-footer as |footer|}}
+              <div style="height: 50px; background-color: rgba(0,0,0,0.08);">
+              </div>
+            {{/chapter.page-footer}}
+            {{! template-lint-enable no-inline-styles}}
+          {{/document.chapter}}
+        {{/printable-pages}}
+      `);
+    };
+
+    test("1 item", async function(assert) {
+      this.set("sectionCount", 1);
+
+      await renderTemplate(this);
+
+      assert.dom("[data-test-page]").exists({ count: 1 });
+      assert
+        .dom("[data-test-page='1'] [data-test-section-item]")
+        .exists({ count: this.sectionCount });
+      assert.dom("[data-test-page='1'] [data-test-page-header]").exists();
+      assert.dom("[data-test-page='1'] [data-test-page-footer]").exists();
+    });
+
+    test("2 items", async function(assert) {
+      this.set("sectionCount", 2);
+
+      await renderTemplate(this);
+
+      assert.dom("[data-test-page]").exists({ count: 2 });
+      assert
+        .dom("[data-test-page='1'] [data-test-section-item]")
+        .exists({ count: 1 });
+      assert.dom("[data-test-page='1'] [data-test-page-header]").exists();
+      assert.dom("[data-test-page='1'] [data-test-page-footer]").exists();
+
+      assert
+        .dom("[data-test-page='2'] [data-test-section-item]")
+        .exists({ count: 1 });
+      assert.dom("[data-test-page='2'] [data-test-page-header]").exists();
+      assert.dom("[data-test-page='2'] [data-test-page-footer]").exists();
+    });
+
+    test("3 items", async function(assert) {
+      this.set("sectionCount", 3);
+
+      await renderTemplate(this);
+
+      assert.dom("[data-test-page]").exists({ count: 3 });
+      assert
+        .dom("[data-test-page='1'] [data-test-section-item]")
+        .exists({ count: 1 });
+      assert.dom("[data-test-page='1'] [data-test-page-header]").exists();
+      assert.dom("[data-test-page='1'] [data-test-page-footer]").exists();
+
+      assert
+        .dom("[data-test-page='2'] [data-test-section-item]")
+        .exists({ count: 1 });
+      assert.dom("[data-test-page='2'] [data-test-page-header]").exists();
+      assert.dom("[data-test-page='2'] [data-test-page-footer]").exists();
+
+      assert
+        .dom("[data-test-page='3'] [data-test-section-item]")
+        .exists({ count: 1 });
+      assert.dom("[data-test-page='3'] [data-test-page-header]").exists();
+      assert.dom("[data-test-page='3'] [data-test-page-footer]").exists();
+    });
+
+    test("8 items", async function(assert) {
+      this.set("sectionCount", 8);
+
+      await renderTemplate(this);
+
+      assert.dom("[data-test-page]").exists({ count: 8 });
+      [...Array(Number(this.sectionCount))]
+        .map((_, i) => i + 1)
+        .forEach(i =>
+          assert
+            .dom(`[data-test-page='${i}'] [data-test-section-item]`)
+            .exists({ count: 1 })
+        );
+    });
+  });
 });


### PR DESCRIPTION
Not sure if the actual bug is elsewhere, but I have only one section with 3 items, each of them big enough to use a complete page. When the second page overflows say by items[1] and items[2],moveItemToNextPage executes and I don't know why this.isFinishedRendering returns false, but inside renderNextPage, lastSectionInPage.isFullyRendered returns true, I guess its mostly bc of how the addon is built that we need to double check before doing anything, which makes sense... but the else case assumes there's another section, and that's what this PR addresses

