### PR TITLE
Bugfix: unit arg

### DIFF
--- a/addon/components/printable-pages.js
+++ b/addon/components/printable-pages.js
@@ -61,7 +61,7 @@ export default class PrintablePagesComponent extends Component {
   }
 
   get pageLayout() {
-    let units = isBlank(this.units) ? DEFAULT_DIMENSIONS.units : this.units;
+    let units = isBlank(this.args.units) ? DEFAULT_DIMENSIONS.units : this.units;
     let width = getOrDefault(this.args, "dimensions", "width");
     let height = getOrDefault(this.args, "dimensions", "height");
     let top = getOrDefault(this.args, "margins", "top");

--- a/addon/components/printable-pages.js
+++ b/addon/components/printable-pages.js
@@ -61,7 +61,10 @@ export default class PrintablePagesComponent extends Component {
   }
 
   get pageLayout() {
-    let units = isBlank(this.args.units) ? DEFAULT_DIMENSIONS.units : this.args.units;
+    let units = get(this.args, 'units');
+    if(isBlank(units)) {
+      units = DEFAULT_DIMENSIONS['units'];
+    }
     let width = getOrDefault(this.args, "dimensions", "width");
     let height = getOrDefault(this.args, "dimensions", "height");
     let top = getOrDefault(this.args, "margins", "top");

--- a/addon/components/printable-pages.js
+++ b/addon/components/printable-pages.js
@@ -61,7 +61,7 @@ export default class PrintablePagesComponent extends Component {
   }
 
   get pageLayout() {
-    let units = isBlank(this.args.units) ? DEFAULT_DIMENSIONS.units : this.units;
+    let units = isBlank(this.args.units) ? DEFAULT_DIMENSIONS.units : this.args.units;
     let width = getOrDefault(this.args, "dimensions", "width");
     let height = getOrDefault(this.args, "dimensions", "height");
     let top = getOrDefault(this.args, "margins", "top");


### PR DESCRIPTION
A quick fix needed when switching to `mm`.  I think it got skipped over during the modernization effort.